### PR TITLE
Don't use git pull --no-rebase/--ff so we work with old git

### DIFF
--- a/bin/pyenv-update
+++ b/bin/pyenv-update
@@ -55,7 +55,13 @@ update_repo() {
   info "Updating $1..."
   verify_repo "$1" &&
   # pyenv-installer makes the repos shallow, so tags are not fetched by default
-  ( cd "${repo}" && git pull --tags --no-rebase --ff "${REMOTE}" "${BRANCH_CHOICE}" )
+  # Use git fetch & merge instead of git pull --ff-only to play nice with old
+  # git.
+  (
+    cd "${repo}" && \
+    git fetch --tags "${REMOTE}" "${BRANCH_CHOICE}" && \
+    git merge --ff-only "${REMOTE}" "${BRANCH_CHOICE}"
+  )
 }
 
 info() {


### PR DESCRIPTION
Old but still active distros like CentOS and RHEL 7 have old Git versions (on RHEL 7.9, Git 1.8.3.1) that don't support the `--no-rebase` the `--ff` flags for `git pull`. We should still work on those systems, so use `git fetch ... && git merge --ff-only ...` to work around the missing flags. Note that we can't use `git pull --ff-only` because it appears to be broken when used with `--tags`.

Tested by "updating" `pyenv-virtualenv`:
1. [Forked`pyenv-virtualenv`](https://github.com/kroeschl/pyenv-virtualenv).
1. Reset my fork's `master` to `HEAD~6`.
1. On a RHEL 7.9 system, ran a tweaked `pyenv-installer` pointing at my fork.
1. Did a `pyenv update`.
1. Patched `~/pyenv/plugins/pyenv-update/bin/pyenv-update` in-place.
1. Reset my `pyenv-virtualenv` fork back to upstream master.
2. Did another `pyenv update` and observed success for `pyenv-virtualenv`.

Fixes #13 and #14.